### PR TITLE
Fix Loading only first Mapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scriptkeys"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "ScriptKeys allows you to easily build macros (in Lua) on every key press for the supported devices."
 documentation = "https://github.com/bigmstone/scriptkeys/blob/main/README.md"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,13 +30,13 @@ pub enum ConfigEvent {
     Script,
 }
 
-#[derive(Deserialize, PartialEq)]
+#[derive(Deserialize, PartialEq, Debug)]
 pub struct Mapping {
     pub key: u32,
     pub script: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct Config {
     pub device: Devices,
     pub mappings: Vec<Mapping>,
@@ -157,3 +157,4 @@ async fn config_watcher(
         }
     }
 }
+

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -16,7 +16,7 @@ pub struct Event {
     pub action: Action,
 }
 
-#[derive(Deserialize, PartialEq)]
+#[derive(Deserialize, PartialEq, Debug)]
 pub enum Devices {
     XK68JS,
     Dummy,
@@ -55,3 +55,4 @@ impl Device for Dummy {
         }
     }
 }
+

--- a/src/device/xkeys/xk68js.rs
+++ b/src/device/xkeys/xk68js.rs
@@ -30,6 +30,7 @@ use std::collections::HashMap;
 use {
     anyhow::{Error, Result},
     hidapi::{HidApi, HidDevice},
+    log::trace,
     serde::Deserialize,
     tokio::sync::mpsc::Sender,
 };
@@ -153,6 +154,7 @@ impl Device for XK68JS {
             let txc = tx.clone();
             tokio::spawn(async move {
                 for event in events {
+                    trace!("Sending event: {:?}", event);
                     txc.send(event).await.unwrap();
                 }
             });
@@ -189,3 +191,4 @@ mod test {
         }
     }
 }
+


### PR DESCRIPTION
Recent change introduced a bug where only the first mapping is added. This was because the mapping parser broke the loop after the fist mapping instead of continuing. This commit fixes that issue and adds additional tracing log messages to help in troubleshooting similar issues in the future. If I wasn't being lazy I would have written at test for this, but I'm being lazy today. Closes #9 