### PR TITLE
Helper Functions Broken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,7 +676,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scriptkeys"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scriptkeys"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "ScriptKeys allows you to easily build macros (in Lua) on every key press for the supported devices."
 documentation = "https://github.com/bigmstone/scriptkeys/blob/main/README.md"


### PR DESCRIPTION
Fixing helper functions. These were broken becasue of the use of `blocking_send` for tokio channels. Ultimately the lua functions are executied within the async tokio context but the compiler has no way to know this. So you can't use await inside a non-async function but blocking inside the async context will fail. So you must spawn out a new async task and await the async send for this to work properly. Fixes #13 