### PR TITLE
Add support for MacOS Aux Keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,7 +126,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -124,7 +139,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "foreign-types",
  "libc",
@@ -325,7 +340,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "inotify-sys",
  "libc",
 ]
@@ -370,7 +385,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -504,7 +519,7 @@ version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5738a2795d57ea20abec2d6d76c6081186709c0024187cd5977265eda6598b51"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -542,6 +557,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
+]
+
+[[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -624,7 +738,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -633,7 +747,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -686,6 +800,9 @@ dependencies = [
  "log4rs",
  "mlua",
  "notify",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "serde",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,8 @@ mlua = { version = "0.8", features = ["lua54", "vendored", "send"] }
 directories = "5.0"
 log4rs = "1.2"
 log = "0.4"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = { version = "0.5", features = [ "relax-void-encoding" ] }
+objc2-foundation = { version = "0.2", features = [ "NSGeometry" ] }
+objc2-app-kit = { version = "0.2", features = [ "NSEvent", "NSGraphicsContext" ] }

--- a/README.md
+++ b/README.md
@@ -1,22 +1,26 @@
 # ScriptKeys
+
 A simple mapping from key press to Lua script. Map a key index to a Lua script
 to automate different tedious tasks.
 
 # Installation
+
 1. `cargo install scriptkeys` will pull from Crates.io for easy installation
 2. Alternatively this can be built locally how you would expect
-    1. `cargo build --release`
-    2. Locate the binary `./target/release/scriptkeys` to relevant `PATH` directory
+   1. `cargo build --release`
+   2. Locate the binary `./target/release/scriptkeys` to relevant `PATH` directory
 
 Brew and other system level packaging is likely a worthwhile investment for the
 future.
 
 # Configuration
+
 Configuration location follows this logic: file name of either `config.toml` or
 `scriptkeys.toml` in either the working directory, the `~/.config` directory, or
 `~/.scriptkeys` directory.
 
 Example Configuration:
+
 ```
 device = 'XK68JS'
 
@@ -30,10 +34,12 @@ script = 'Script2.lua'
 ```
 
 # Writing Scripts
+
 Scripts are stored in either the `./.scripts` directory (where ./ is the working
 directory of the binary) or in `~/.scriptkeys/scripts/` directory.
 
 The lua scripts are straight forward and should follow this structure:
+
 ```
 Test = Test or {}
 
@@ -51,17 +57,22 @@ the Lua Table is named `Test` so the Lua file would need to be named `Test.lua`.
 The Lua Table and Lua file can be named whatever you like but they must match.
 
 ## Available helper functions
+
 Inside the Lua context there are helper functions for emulating keyboard keys,
 if desired. Below is a list of these.
 
-* `keyClick("<char>")`
-* `keyPress("<char>")`
-* `keyRelease("<char>")`
-* `rawKeyClick(<u16>)`
-* `rawKeyPress(<u16>)`
-* `rawKeyRelease(<u16>)`
+- `keyClick("<char>")`
+- `keyPress("<char>")`
+- `keyRelease("<char>")`
+- `rawKeyClick(<u16>)`
+- `rawKeyPress(<u16>)`
+- `rawKeyRelease(<u16>)`
+- `hid_post_aux_key(<u32>, <bool>)`
+  - Note: This function is MacOS only
+  - The first variable is the key type and the second is if the key is down or up
 
 Example:
+
 ```
 Test = Test or {}
 
@@ -89,4 +100,5 @@ A full list of the mappings can be found in the
 helper function
 
 # Supported Devices
-* XKeys 68 JS
+
+- XKeys 68 JS


### PR DESCRIPTION
Add support for MacOS Aux Keys as well as updating execution of scripts so that script environment doesn't fail if script fails. README updated for new helpers.

Closes #15 